### PR TITLE
update to 1.19.2, works on .4 as well

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '0.10-SNAPSHOT'
+    id 'fabric-loom' version '0.12-SNAPSHOT'
     id 'maven-publish'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ sourceCompatibility = JavaVersion.VERSION_17
 targetCompatibility = JavaVersion.VERSION_17
 
 archivesBaseName = project.archives_base_name
-version = project.mod_version
+version = "${project.mod_version}-mc${project.minecraft_version}"
 group = project.maven_group
 
 dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,13 +2,13 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.18.2
-yarn_mappings=1.18.2+build.2
-loader_version=0.13.3
+minecraft_version=1.19.2
+yarn_mappings=1.19.2+build.28
+loader_version=0.14.14
 # Mod Properties
 mod_version=1.3.2
 maven_group=me.techchrism
 archives_base_name=ticktock
 # Dependencies
 # check this on https://modmuss50.me/fabric.html
-fabric_version=0.48.0+1.18.2
+fabric_version=0.76.1+1.19.2

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -19,7 +19,7 @@
   "depends": {
     "fabricloader": ">=0.10.1+build.209",
     "fabric": "*",
-    "minecraft": "1.18.2"
+    "minecraft": ">=1.19.2"
   },
   "mixins": [
     "ticktock.mixins.json"


### PR DESCRIPTION
(doubt this needed more than the version unlock in `fabric.mod.json` that's why I've moved to `>=`)
might be nice to have separate branches for versions so multiple versions can be supported
would also be cool if the project got added to Modrinth